### PR TITLE
Initial work

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,35 +8,81 @@ In the current version, `krux_elb.elb.ELB` is only compatible with `krux_boto.bo
 
 ## Application quick start
 
-The most common use case is to build a CLI script using `krux_boto.cli.Application`.
+The most common use case is to build a CLI script using `krux_elb.cli.Application`.
 Here's how to do that:
 
 ```python
 
-from krux_boto.cli import Application
-from krux_elb.elb import ELB
+import krux_elb.cli
+
+# This class inherits from krux.cli.Application, so it provides
+# all that functionality as well.
+class Application(krux_elb.cli.Application):
+    def run(self):
+        print self.elb.find_load_balancers(
+            instance='i-a1b2c3d4'
+        )
 
 def main():
-    # The name must be unique to the organization. The object
-    # returned inherits from krux.cli.Application, so it provides
-    # all that functionality as well.
-    app = Application(name='krux-my-boto-script')
+    # The name must be unique to the organization.
+    app = Application(name='krux-my-s3-script')
+    with app.context():
+        app.run()
 
-    ec2 = EC2(boto=app.boto)
-    f = Filter({
-        'tag:Name': 'example.krxd.net',
-        'instance-state-name': ['running', 'stopped'],
-    })
-    instance = ec2.find_instances(f)
-
-    elb = ELB(boto=app.boto)
-    print self.elb.find_load_balancers(
-        instance=instance[0]
-    )
-
-### Run the application stand alone
+# Run the application stand alone
 if __name__ == '__main__':
     main()
+
+```
+
+## Extending your application
+
+From other CLI applications, you can make the use of `krux_elb.elb.get_elb()` function.
+
+```python
+
+from krux_elb.elb import add_elb_cli_arguments, get_elb
+import krux.cli
+
+class Application(krux.cli.Application):
+
+    def __init__(self, *args, **kwargs):
+        super(Application, self).__init__(*args, **kwargs)
+
+        self.elb = get_elb(self.args, self.logger, self.stats)
+
+    def add_cli_arguments(self, parser):
+        super(Application, self).add_cli_arguments(parser)
+
+        add_elb_cli_arguments(parser)
+
+```
+
+Alternately, you want to add ELB functionality to your larger script or application.
+Here's how to do that:
+
+```python
+
+from krux_boto import Boto
+from krux_elb import ELB
+
+class MyApplication(object):
+
+    def __init__(self, *args, **kwargs):
+        boto = Boto(
+            logger=self.logger,
+            stats=self.stats,
+        )
+        self.elb = ELB(
+            boto=boto,
+            logger=self.logger,
+            stats=self.stats,
+        )
+
+    def run(self):
+        print self.elb.find_load_balancers(
+            instance='i-a1b2c3d4'
+        )
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
 # krux_elb
+
+`krux_elb` is a library that provides wrapper functions for common S3 usage. It uses `krux_boto` to connect to AWS ELB.
+
+## Warning
+
+In the current version, `krux_elb.elb.ELB` is only compatible with `krux_boto.boto.Boto` object. Passing other objects, such as `krux_boto.boto.Boto3`, will cause an exception.
+
+## Application quick start
+
+The most common use case is to build a CLI script using `krux_boto.cli.Application`.
+Here's how to do that:
+
+```python
+
+from krux_boto.cli import Application
+from krux_elb.elb import ELB
+
+def main():
+    # The name must be unique to the organization. The object
+    # returned inherits from krux.cli.Application, so it provides
+    # all that functionality as well.
+    app = Application(name='krux-my-boto-script')
+
+    ec2 = EC2(boto=app.boto)
+    f = Filter({
+        'tag:Name': 'example.krxd.net',
+        'instance-state-name': ['running', 'stopped'],
+    })
+    instance = ec2.find_instances(f)
+
+    elb = ELB(boto=app.boto)
+    print self.elb.find_load_balancers(
+        instance=instance[0]
+    )
+
+### Run the application stand alone
+if __name__ == '__main__':
+    main()
+
+```
+
+As long as you get an instance of `krux_boto.boto.Boto`, the rest are the same. Refer to `krux_boto` module's [README](https://github.com/krux/python-krux-boto/blob/master/README.md) on various ways to instanciate the class.

--- a/krux_elb/cli.py
+++ b/krux_elb/cli.py
@@ -19,15 +19,6 @@ import krux_boto.cli
 from krux_elb.elb import add_elb_cli_arguments, get_elb, NAME
 
 
-class MockInstance(object):
-    """
-    Instance existing only as a demonstration purpose. Do not use outside of this file.
-    """
-
-    def __init__(self, instance_id):
-        self.id = instance_id
-
-
 class Application(krux_boto.cli.Application):
 
     def __init__(self, name=NAME):
@@ -46,7 +37,7 @@ class Application(krux_boto.cli.Application):
         print self.elb.find_load_balancers(
             # console-b001.krxd.net
             # Arbitrary chosen as a test instance
-            instance=MockInstance('i-16137da5')
+            instance_id='i-16137da5'
         )
 
 

--- a/krux_elb/cli.py
+++ b/krux_elb/cli.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# © 2016 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+
+from __future__ import absolute_import
+import os
+
+#
+# Internal libraries
+#
+
+from krux.cli import get_group
+import krux_boto.cli
+from krux_elb.elb import add_elb_cli_arguments, get_elb, NAME
+
+
+class MockInstance(object):
+    """
+    Instance existing only as a demonstration purpose. Do not use outside of this file.
+    """
+
+    def __init__(self, instance_id):
+        self.id = instance_id
+
+
+class Application(krux_boto.cli.Application):
+
+    def __init__(self, name=NAME):
+        # Call to the superclass to bootstrap.
+        super(Application, self).__init__(name=name)
+
+        self.elb = get_elb(self.args, self.logger, self.stats)
+
+    def add_cli_arguments(self, parser):
+        # Call to the superclass
+        super(Application, self).add_cli_arguments(parser)
+
+        add_elb_cli_arguments(parser, include_boto_arguments=False)
+
+    def run(self):
+        print self.elb.find_load_balancers(
+            # console-b001.krxd.net
+            # Arbitrary chosen as a test instance
+            instance=MockInstance('i-16137da5')
+        )
+
+
+def main():
+    app = Application()
+    with app.context():
+        app.run()
+
+
+# Run the application stand alone
+if __name__ == '__main__':
+    main()

--- a/krux_elb/elb.py
+++ b/krux_elb/elb.py
@@ -52,23 +52,20 @@ class ELB(object):
 
     def __init__(
         self,
+        boto,
         logger=None,
         stats=None,
-        parser=None,
     ):
         # Private variables, not to be used outside this module
         self._name = NAME
         self._logger = logger or get_logger(self._name)
         self._stats = stats or get_stats(prefix=self._name)
-        self._parser = parser or get_parser(description=self._name)
-        self._args = self._parser.parse_args()
 
-        # Add the boto connector
-        self.boto = Boto(
-            parser=self._parser,
-            logger=self._logger,
-            stats=self._stats,
-        )
+        # Throw exception when Boto2 is not used
+        if not isinstance(boto, Boto):
+            raise TypeError('krux_elb.elb.ELB only supports krux_boto.boto.Boto')
+
+        self.boto = boto
 
         # Set up default cache
         self._conn = None

--- a/krux_elb/elb.py
+++ b/krux_elb/elb.py
@@ -102,6 +102,7 @@ class ELB(object):
         self._stats = stats or get_stats(prefix=self._name)
 
         # Throw exception when Boto2 is not used
+        # TODO: Start using Boto3 and reverse this check
         if not isinstance(boto, Boto):
             raise TypeError('krux_elb.elb.ELB only supports krux_boto.boto.Boto')
 

--- a/krux_elb/elb.py
+++ b/krux_elb/elb.py
@@ -25,6 +25,46 @@ import boto.ec2.elb
 NAME = 'krux-elb'
 
 
+def get_elb(args=None, logger=None, stats=None):
+    """
+    Return a usable ELB object without creating a class around it.
+
+    In the context of a krux.cli (or similar) interface the 'args', 'logger'
+    and 'stats' objects should already be present. If you don't have them,
+    however, we'll attempt to provide usable ones for the SQS setup.
+
+    (If you omit the add_elb_cli_arguments() call during other cli setup,
+    the Boto object will still work, but its cli options won't show up in
+    --help output)
+
+    (This also handles instantiating a Boto object on its own.)
+    """
+    if not args:
+        parser = get_parser()
+        add_elb_cli_arguments(parser)
+        args = parser.parse_args()
+
+    if not logger:
+        logger = get_logger(name=NAME)
+
+    if not stats:
+        stats = get_stats(prefix=NAME)
+
+    boto = Boto(
+        log_level=args.boto_log_level,
+        access_key=args.boto_access_key,
+        secret_key=args.boto_secret_key,
+        region=args.boto_region,
+        logger=logger,
+        stats=stats,
+    )
+    return ELB(
+        boto=boto,
+        logger=logger,
+        stats=stats,
+    )
+
+
 def add_elb_cli_arguments(parser, include_boto_arguments=True):
     """
     Utility function for adding ELB specific CLI arguments.

--- a/krux_elb/elb.py
+++ b/krux_elb/elb.py
@@ -120,7 +120,7 @@ class ELB(object):
 
         return self._conn
 
-    def find_load_balancers(self, instance):
+    def find_load_balancers(self, instance_id):
         """
         Returns a list of ELB that the given instance is behind
         """
@@ -128,36 +128,36 @@ class ELB(object):
 
         load_balancers = [
             lb for lb in elb.get_all_load_balancers()
-            if instance.id in [i.id for i in lb.instances]
+            if instance_id in [i.id for i in lb.instances]
         ]
 
         self._logger.info('Found following load balancers: %s', load_balancers)
 
         if len(load_balancers) > 1:
-            self._logger.warning('The given instance is under multiple load balancers: %s', load_balancers)
+            self._logger.warning('The instance %s is under multiple load balancers: %s', instance_id, load_balancers)
 
         return load_balancers
 
-    def remove_instance(self, instance, load_balancer_name):
+    def remove_instance(self, instance_id, load_balancer_name):
         """
         Removes the given instance from the ELB with the given name.
         """
         elb = self._get_connection()
         try:
-            elb.deregister_instances(load_balancer_name, [instance.id])
+            elb.deregister_instances(load_balancer_name, [instance_id])
         except boto.exception.BotoServerError:
             trace = sys.exc_info()[2]
             raise ELBInstanceMismatchError(), None, trace
-        self._logger.info('Removed instance %s from load balancer %s', instance.tags.get('Name'), load_balancer_name)
+        self._logger.info('Removed instance %s from load balancer %s', instance_id, load_balancer_name)
 
-    def add_instance(self, instance, load_balancer_name):
+    def add_instance(self, instance_id, load_balancer_name):
         """
         Adds the given instance to the ELB with the given name.
         """
         elb = self._get_connection()
         try:
-            elb.register_instances(load_balancer_name, [instance.id])
+            elb.register_instances(load_balancer_name, [instance_id])
         except boto.exception.BotoServerError:
             trace = sys.exc_info()[2]
             raise ELBInstanceMismatchError(), None, trace
-        self._logger.info('Added instance %s to load balancer %s', instance.tags.get('Name'), load_balancer_name)
+        self._logger.info('Added instance %s to load balancer %s', instance_id, load_balancer_name)

--- a/krux_elb/elb.py
+++ b/krux_elb/elb.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+#
+# © 2015 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+
+from __future__ import absolute_import
+import sys
+
+#
+# Third party libraries
+#
+
+from krux_boto import Boto, add_boto_cli_arguments
+from krux.logging import get_logger
+from krux.stats import get_stats
+from krux.cli import get_parser, get_group
+import boto.ec2
+import boto.ec2.elb
+
+
+NAME = 'krux-elb'
+
+
+def add_elb_cli_arguments(parser, include_boto_arguments=True):
+    """
+    Utility function for adding ELB specific CLI arguments.
+    """
+    if include_boto_arguments:
+        # GOTCHA: Since ELB both uses Boto, the Boto's CLI arguments can be included multiple times,
+        # when used with other libraries, causing an error. This creates a way to circumvent that.
+
+        # Add all the boto arguments
+        add_boto_cli_arguments(parser)
+
+    # Add those specific to the application
+    group = get_group(parser, NAME)
+
+
+class ELBInstanceMismatchError(StandardError):
+    pass
+
+
+class ELB(object):
+    """
+    A manager to handle all ELB related functions.
+    Each instance is locked to a connection to a designated region (self.boto.cli_region).
+    """
+
+    def __init__(
+        self,
+        logger=None,
+        stats=None,
+        parser=None,
+    ):
+        # Private variables, not to be used outside this module
+        self._name = NAME
+        self._logger = logger or get_logger(self._name)
+        self._stats = stats or get_stats(prefix=self._name)
+        self._parser = parser or get_parser(description=self._name)
+        self._args = self._parser.parse_args()
+
+        # Add the boto connector
+        self.boto = Boto(
+            parser=self._parser,
+            logger=self._logger,
+            stats=self._stats,
+        )
+
+        # Set up default cache
+        self._conn = None
+
+    def _get_connection(self):
+        """
+        Returns a connection to the designated region (self.boto.cli_region).
+        The connection is established on the first call for this instance (lazy) and cached.
+        """
+        if self._conn is None:
+            self._conn = self.boto.ec2.elb.connect_to_region(self.boto.cli_region)
+
+        return self._conn
+
+    def find_load_balancers(self, instance):
+        """
+        Returns a list of ELB that the given instance is behind
+        """
+        elb = self._get_connection()
+
+        load_balancers = [
+            lb for lb in elb.get_all_load_balancers()
+            if instance.id in [i.id for i in lb.instances]
+        ]
+
+        self._logger.info('Found following load balancers: %s', load_balancers)
+
+        if len(load_balancers) > 1:
+            self._logger.warning('The given instance is under multiple load balancers: %s', load_balancers)
+
+        return load_balancers
+
+    def remove_instance(self, instance, load_balancer_name):
+        """
+        Removes the given instance from the ELB with the given name.
+        """
+        elb = self._get_connection()
+        try:
+            elb.deregister_instances(load_balancer_name, [instance.id])
+        except boto.exception.BotoServerError:
+            trace = sys.exc_info()[2]
+            raise ELBInstanceMismatchError(), None, trace
+        self._logger.info('Removed instance %s from load balancer %s', instance.tags.get('Name'), load_balancer_name)
+
+    def add_instance(self, instance, load_balancer_name):
+        """
+        Adds the given instance to the ELB with the given name.
+        """
+        elb = self._get_connection()
+        try:
+            elb.register_instances(load_balancer_name, [instance.id])
+        except boto.exception.BotoServerError:
+            trace = sys.exc_info()[2]
+            raise ELBInstanceMismatchError(), None, trace
+        self._logger.info('Added instance %s to load balancer %s', instance.tags.get('Name'), load_balancer_name)

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
+            'krux-elb-test = krux_elb.cli:main',
         ],
     },
     test_suite='test',


### PR DESCRIPTION
Thin wrapper for EC2, just like [python-krux-boto-sqs](https://github.com/krux/python-krux-boto-sqs).

98% of the code in `krux_elb/elb.py` is copy and paste from [python-krux-manage-instance](https://github.com/krux/python-krux-manage-instance/blob/master/krux_elb/elb.py), and thus reviewed before.
